### PR TITLE
Add bash script to download necessary files for Colab

### DIFF
--- a/pa4.ipynb
+++ b/pa4.ipynb
@@ -25,6 +25,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%bash\n",
+    "\n",
+    "if [[ ! -d \"./data\" ]]\n",
+    "then\n",
+    "    echo \"Missing extra files (this probably means you're running on Google Colab). Downloading...\"\n",
+    "    git clone https://github.com/cs124/pa4-quizlet.git\n",
+    "    cp -r ./pa4-quizlet/{data,quizlet.py} .\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Do not modify this cell, please just run it!\n",
     "import quizlet"
    ]


### PR DESCRIPTION
I have been running these notebooks in Colab instead of Jupyter notebook and I have had to include a script like this for past assignments:

```
%%bash

if [[ ! -d "./data" ]]
then
    echo "Missing extra files (this probably means you're running on Google Colab). Downloading..."
    git clone https://github.com/cs124/pa4-quizlet.git
    cp -r ./pa4-quizlet/{data,quizlet.py} .
fi
```

This script was present in the first assignment. 